### PR TITLE
Update Amplify build configuration for Python 3.13 compatibility

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,14 +1,14 @@
 version: 1
 runtime-versions:
   nodejs: 18
-  python: 3.10
+  python: 3.13
 
 backend:
   phases:
     preBuild:
       commands:
         - python3 -m pip install uv
-        - uv sync
+        - python3 -m uv sync
     build:
       commands:
         - amplifyPush --simple


### PR DESCRIPTION
This pull request updates the Amplify build configuration to use Python 3.13. Additionally, adjustments have been made to the sync command to ensure compatibility with the updated Python version.