### PR TITLE
Update Python version and refine build configurations

### DIFF
--- a/amplify/backend/function/fastapilambda/Pipfile
+++ b/amplify/backend/function/fastapilambda/Pipfile
@@ -11,4 +11,4 @@ mangum = "*"
 app = {editable = true, path = "../../../../backend"}
 
 [requires]
-python_version = "3.13"
+python_version = "3.10"

--- a/amplify/backend/function/fastapilambda/Pipfile.lock
+++ b/amplify/backend/function/fastapilambda/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "541c9b1ed983d0a68654b4b662d27b037f60a9dd196b7c21bd120e9703876b31"
+            "sha256": "02c311876319a9c8db72bfe71d70fe79a01777cf4554ae1a89bc766f8dda7173"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.13"
+            "python_version": "3.10"
         },
         "sources": [
             {


### PR DESCRIPTION
### Summary of Changes
- Downgraded Python version to 3.10 in `Pipfile` and `Pipfile.lock`.
- Updated `uv.lock` to require Python >=3.10 and included updated dependencies.
- Refined build commands for Amplify configuration with Python 3.10.
- Adjusted Amplify build configuration to utilize Python 3.13 and improved the sync command.

### Checklist
- [ ] Ensure compatibility with updated Python version.
- [ ] Validate build configurations for Amplify.